### PR TITLE
Add "did you mean" suggestion to no files matched error

### DIFF
--- a/contrib/verify-binaries/verify.py
+++ b/contrib/verify-binaries/verify.py
@@ -509,7 +509,9 @@ def verify_published_handler(args: argparse.Namespace) -> ReturnCode:
     # Extract hashes and filenames
     hashes_to_verify = parse_sums_file(SUMS_FILENAME, [os_filter])
     if not hashes_to_verify:
-        log.error("no files matched the platform specified. check available versions on bitcoincore.org/bin")
+        available_versions = ["-".join(line[1].split("-")[2:]) for line in parse_sums_file(SUMS_FILENAME, [])]
+        closest_match = difflib.get_close_matches(os_filter, available_versions, cutoff=0, n=1)[0]
+        log.error("No files matched the platform specified. Did you mean: "+closest_match)
         return ReturnCode.NO_BINARIES_MATCH
 
     # remove binaries that are known not to be hosted by bitcoincore.org


### PR DESCRIPTION
Will Clark suggested changing the message when no files matched to not suggest a particular domain.
While the original did not help the user solve their error. This one returns the closest platform string to what the user typed

When a user types a platform string that cannot be found in any filename, lets be helpful and tell them the platform found closest to what they typed. This will save some frustration if someone doesn't know exactly what we name our files but is using this tool.

Uses the `difflib` Python built-in which was already imported for use elsewhere in this script.